### PR TITLE
bump sharedb deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "repository": "share/sharedb-postgres",
   "dependencies": {
     "pg": "^4.5.1",
-    "sharedb": "^0.11.34"
+    "sharedb": "^1.0.0-beta.7"
   }
 }


### PR DESCRIPTION
According to this #2 we need to use the `1.0.0` version of sharedb.