### PR TITLE
Fix snapshot commit metadata on conflict

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ PostgresDB.prototype.commit = async function(collection, id, op, snapshot, optio
     WHERE collection = $1 AND doc_id = $2
     FOR UPDATE
   )
-  ON CONFLICT (collection, doc_id) DO UPDATE SET version = $3, data = $5, doc_type = $4, metadata = $5
+  ON CONFLICT (collection, doc_id) DO UPDATE SET version = $3, data = $5, doc_type = $4, metadata = $6
   RETURNING version
 )
 INSERT INTO ops (collection, doc_id, version, operation)


### PR DESCRIPTION
fix when updating the snapshot table, the metadata field was mistakenly updated to the data field